### PR TITLE
Correction of Skyblock feature

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
 
     -   repo: https://github.com/astral-sh/ruff-pre-commit
         # Ruff version.
-        rev: v0.6.7
+        rev: v0.6.8
         hooks:
             # Run the linter.
             -   id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
 
     -   repo: https://github.com/astral-sh/ruff-pre-commit
         # Ruff version.
-        rev: v0.6.6
+        rev: v0.6.7
         hooks:
             # Run the linter.
             -   id: ruff

--- a/chouette/commands/skyblock.py
+++ b/chouette/commands/skyblock.py
@@ -104,7 +104,7 @@ class Skyblock(app_commands.Group):
         discord_pseudo = interaction.user.name
         async with aiohttp.ClientSession() as session:
             profile_name = await pseudo_to_profile(
-                session, interaction.client.config["HYPIXEL_KEY"], discord_pseudo, pseudo, profile
+                session, interaction.client, discord_pseudo, pseudo, profile
             )
         if isinstance(profile_name, str):
             interaction.client.bot_logger.error(profile_name)

--- a/chouette/utils/ranking.py
+++ b/chouette/utils/ranking.py
@@ -6,7 +6,13 @@ import discord
 
 from chouette.utils.birthdays import month_to_str
 from chouette.utils.hypixel_data import experience_to_level
-from chouette.utils.skyblock import get_profile, get_stats, load_skyblock, save_skyblock
+from chouette.utils.skyblock import (
+    get_hypixel_player,
+    get_profile,
+    get_stats,
+    load_skyblock,
+    save_skyblock,
+)
 
 SPACES = " " * 38
 
@@ -35,7 +41,8 @@ async def update_stats(api_key: str) -> str:
             if not profile[0]:
                 raise Exception("Error while updating stats")
             profile = profile[1]
-            new_data.get(uuid).update(await get_stats(session, api_key, pseudo, uuid, profile))
+            player = await get_hypixel_player(session, api_key, uuid)
+            new_data.get(uuid).update(await get_stats(session, pseudo, uuid, player, profile))
             msg += f"\n{SPACES}- {pseudo} sur le profil {profile_name}"
     await save_skyblock(new_data)
     # TODO: handle comparison using old and new data (see issue #56)

--- a/chouette/utils/skyblock.py
+++ b/chouette/utils/skyblock.py
@@ -35,17 +35,11 @@ async def minecraft_uuid(session: ClientSession, pseudo: str) -> tuple[bool, str
         return True, json.get("id")
 
 
-async def hypixel_discord(session: ClientSession, api_key: str, uuid: str) -> tuple[bool, str]:
+async def hypixel_discord(player: dict) -> tuple[bool, str]:
     """Retourne le pseudo Discord lié à un compte Hypixel."""
-    async with session.get(
-        f"{HYPIXEL_API}player", params={"key": api_key, "uuid": uuid}
-    ) as response:
-        json: dict = await response.json()
-        if response.status != 200:
-            return False, json.get("cause")
-        if not json.get("player").get("socialMedia", {}).get("links", {}).get("DISCORD", ""):
-            return False, "Vous n'avez pas associé votre compte Discord à Hypixel"
-        return True, json.get("player").get("socialMedia").get("links").get("DISCORD")
+    if not player.get("player").get("socialMedia", {}).get("links", {}).get("DISCORD", ""):
+        return False, "Vous n'avez pas associé votre compte Discord à Hypixel"
+    return True, player.get("player").get("socialMedia").get("links").get("DISCORD")
 
 
 async def selected_profile(
@@ -109,12 +103,11 @@ async def get_networth(session: ClientSession, pseudo: str, profile_id: str) -> 
         return json.get("profiles").get(profile_id).get("data").get("networth").get("networth", 0)
 
 
-async def get_stats(session, api_key, pseudo, uuid, profile) -> dict[str, float]:
+async def get_stats(session, pseudo, uuid, hypixel_player, profile) -> dict[str, float]:
     """Retourne les statistiques d'un joueur Skyblock avec l'API."""
     info = profile.get("members").get(uuid)
     level: float = (info.get("leveling").get("experience")) / 100
     networth = await get_networth(session, pseudo, profile.get("profile_id"))
-    hypixel_player = await get_hypixel_player(session, api_key, uuid)
     skill = info.get("player_data").get("experience")
     skills: tuple[float, float, float, float, float, float, float, float, float, float] = (
         skill.get("SKILL_FISHING", 0),
@@ -163,7 +156,8 @@ async def pseudo_to_profile(
 
     api_key = client.config.get("HYPIXEL_KEY")
 
-    discord = await hypixel_discord(session, api_key, uuid)
+    player = await get_hypixel_player(session, api_key, uuid)
+    discord = await hypixel_discord(player)
     if not discord[0]:
         # TODO: better handling
         return discord[1]
@@ -183,7 +177,8 @@ async def pseudo_to_profile(
     client.bot_logger.debug(f"Le profil {profile.get('cute_name')} a été trouvé")
 
     info = {uuid: {"discord": discord, "pseudo": pseudo, "profile": profile.get("cute_name")}}
-    info.get(uuid).update(await get_stats(session, api_key, pseudo, uuid, profile))
+    info.get(uuid).update(await get_stats(session, pseudo, uuid, player, profile))
+    client.bot_logger.debug("Les stats ont bien été calculées")
     file_content = await load_skyblock()
     if file_content.get(uuid, {}).get("profile", "") != profile.get("profile_id"):
         file_content.update(info)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
 pre-commit ~= 3.8
-ruff == 0.6.6
+ruff == 0.6.7

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
 pre-commit ~= 3.8
-ruff == 0.6.7
+ruff == 0.6.8


### PR DESCRIPTION
This pull request includes several changes to update dependencies, refactor code for better readability, and improve logging for debugging purposes. The most important changes include updating the `ruff` linter version, refactoring the `skyblock.py` utility functions, and adding logging for better debugging.

### Dependency Updates:
* Updated `ruff` linter version from `v0.6.6` to `v0.6.8` in `.pre-commit-config.yaml` and `requirements-dev.txt`. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L19-R19) [[2]](diffhunk://#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbcL3-R3)

### Code Refactoring:
* Refactored `chouette/utils/skyblock.py` to simplify the `hypixel_discord` function by removing the API call and using the `player` dictionary directly.
* Updated the `get_stats` function in `chouette/utils/skyblock.py` to accept `hypixel_player` as a parameter instead of making an API call within the function.
* Improved import statements in `chouette/utils/ranking.py` for better readability by using multi-line imports.

### Logging Improvements:
* Added debug logging in `pseudo_to_profile` and other relevant functions in `chouette/utils/skyblock.py` to help trace the flow and values during execution. [[1]](diffhunk://#diff-35fb70848001ad9b31229ab6cbc63d1f3621779aa10038238a1186ef8aea46eeL150-R167) [[2]](diffhunk://#diff-35fb70848001ad9b31229ab6cbc63d1f3621779aa10038238a1186ef8aea46eeR177-R181)

### Code Simplification:
* Simplified the `link` function in `chouette/commands/skyblock.py` by removing the `HYPIXEL_KEY` parameter and using the `client` object directly.