### PR TITLE
fix: renovate config and update readme + contributing

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,15 @@
     "config:best-practices",
     "schedule:weekly"
   ],
+  "ignorePresets": [ "helpers:pinGitHubActionDigests" ],
   "baseBranchPatterns": [ "dev" ],
   "timezone": "Europe/Paris",
   "prHourlyLimit": 0,
+  "enabledManagers": [
+    "github-actions",
+    "pep621",
+    "pre-commit"
+  ],
   "packageRules": [
     {
       "matchManagers": [ "pep621", "pre-commit" ],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,11 +26,11 @@ Thank you for considering contributing to ChouetteBot! We appreciate your suppor
 
 5. **Make Changes**.
 
-6. **Format Changes**: Run pre-commit and ruff to ensure code quality.
+6. **Format Changes**: Run prek and Ruff to ensure code quality.
 
    ```sh
-   uv run pre-commit run -a
-   # Running ruff is optional as it's included in the pre-commit config
+   uv run prek run -a
+   # Running Ruff is optional as it's included in the pre-commit config
    uv run ruff check
    uv run ruff format
    ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # ChouetteBot-discord
 
 ![Python version 3.13+](https://img.shields.io/badge/Python-3.13+-blue?logo=python&logoColor=white)
-[![Ruff status](https://img.shields.io/github/actions/workflow/status/Zalk0/ChouetteBot-discord/ruff.yaml?branch=main&logo=github&label=Ruff)](https://github.com/Zalk0/ChouetteBot-discord/actions/workflows/ruff.yaml)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/Zalk0/ChouetteBot-discord/main.svg)](https://results.pre-commit.ci/latest/github/Zalk0/ChouetteBot-discord/main)
+[![CI status](https://img.shields.io/github/actions/workflow/status/Zalk0/ChouetteBot-discord/ci.yaml?branch=main&logo=github&label=CI)](https://github.com/Zalk0/ChouetteBot-discord/actions/workflows/ci.yaml)
 
 Just some random project of doing a Discord bot using
 [discord.py](https://github.com/Rapptz/discord.py).\


### PR DESCRIPTION
This pull request introduces several improvements to project configuration and documentation. The main changes include updating the CI badge in the `README.md`, clarifying formatting instructions in the contribution guide, and refining the Renovate configuration for dependency management.

**Documentation updates:**

* Updated the CI badge in `README.md` to reference the unified `ci.yaml` workflow instead of separate Ruff and pre-commit badges, simplifying status visibility.
* Clarified formatting instructions in `CONTRIBUTING.md` by specifying the use of `prek` instead of `pre-commit` and updating the Ruff instructions for consistency.

**Dependency management configuration:**

* Updated `.github/renovate.json` to ignore the `helpers:pinGitHubActionDigests` preset and explicitly enable the `github-actions`, `pep621`, and `pre-commit` managers, improving Renovate's behavior and coverage.